### PR TITLE
Allow custom config through script metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [1.1.0] - 2024-08-22
+
+### Added
+- Allow custom config of library items via metadata in scripts or profiles ([#1](https://github.com/moojomoore/git2kandji/pull/1))
+- Added a `--download` flag to download all scripts and/or profiles to help getting started with git2kandji ([#1](https://github.com/moojomoore/git2kandji/pull/1))
+
+### Contributions
+- Thanks to [@disenchant](https://github.com/disenchant) for the additions in this release!

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,5 +10,4 @@ USER appuser
 
 RUN pip install --user -r requirements.txt
 
-ENTRYPOINT ["python3"]
-CMD ["/action/git2kandji.py"]
+ENTRYPOINT ["python3", "/action/git2kandji.py"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,14 @@
 FROM python:3-slim
-COPY . /action
+
+RUN adduser --disabled-password --gecos "" appuser
+
+COPY --chown=appuser:appuser . /action
+
 WORKDIR /action
-RUN pip install --root-user-action=ignore -r requirements.txt
+
+USER appuser
+
+RUN pip install --user -r requirements.txt
+
 ENTRYPOINT ["python3"]
 CMD ["/action/git2kandji.py"]

--- a/git2kandji.py
+++ b/git2kandji.py
@@ -838,7 +838,7 @@ def download_profile(library_item_id, profile_dir):
     slugified_name = slugify(profile_name)
 
     # Check if the profile name is already included as a comment
-    comment = f"<!-- git2kandji-config:"
+    comment = f"<!-- git2kandji-config: name = {profile_name} -->"
     if comment not in profile_content:
         # Add the profile name as a comment at the beginning of the XML file after the XML declaration
         profile_content = profile_content.replace("<?xml version=\"1.0\" encoding=\"UTF-8\"?>", f"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n{comment}")

--- a/git2kandji.py
+++ b/git2kandji.py
@@ -772,6 +772,10 @@ def delete_items(kandji_items, local_items, delete_func, dryrun=False):
 # Download Script
 def download_script(library_item_id, script_dir):
     """Download a script from Kandji and save it locally."""
+
+    # Ensure the script directory exists
+    os.makedirs(script_dir, exist_ok=True)
+
     headers = {
         'Authorization': f'Bearer {TOKEN}'
     }
@@ -814,6 +818,10 @@ def download_script(library_item_id, script_dir):
 # Download Profile
 def download_profile(library_item_id, profile_dir):
     """Download a profile from Kandji and save it locally."""
+
+    # Ensure the profile directory exists
+    os.makedirs(profile_dir, exist_ok=True)
+
     headers = {
         'Authorization': f'Bearer {TOKEN}'
     }

--- a/git2kandji.py
+++ b/git2kandji.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-SCRIPT_VERSION = "1.0.0"
+SCRIPT_VERSION = "1.1.0"
 
 import os
 import re
@@ -913,7 +913,6 @@ def main():
         if delete:
             logger.info("Delete flag enabled. Comparing Kandji profiles with the local repo for potential deletions.")
             delete_items(kandji_profiles, local_profiles, delete_custom_profile, dryrun)
-
 
         if download:
             logger.info("Download flag enabled. Downloading all profiles from Kandji.")

--- a/git2kandji.py
+++ b/git2kandji.py
@@ -654,7 +654,7 @@ def sync_kandji_scripts(local_scripts, kandji_scripts, dryrun=False):
         remediation_script = scripts.get('remediation')
 
         # Parse metadata from the audit script (or remediation if audit is missing)
-        metadata_script = audit_script or remediation_script
+        metadata_script = audit_script
 
         metadata = {}
         with open(metadata_script, 'r') as f:

--- a/git2kandji.py
+++ b/git2kandji.py
@@ -361,12 +361,8 @@ def parse_script_metadata(audit_script_path, audit_script_content):
     return metadata
 
 # Create Custom Script
-def create_custom_script(audit_script_path, remediation_script_path=None, script_name=None):
+def create_custom_script(audit_script_path, remediation_script_path=None):
     """Create Kandji Custom Script"""
-
-    # If script_name is not provided, set it from audit_script_path
-    if not script_name:
-        script_name = os.path.basename(audit_script_path)
 
     # Read Audit Script Content
     audit_script_content = ""
@@ -408,12 +404,8 @@ def create_custom_script(audit_script_path, remediation_script_path=None, script
     return response
 
 # Update Custom Script
-def update_custom_script(library_item_id, audit_script_path, remediation_script_path=None, script_name=None):
+def update_custom_script(library_item_id, audit_script_path, remediation_script_path=None):
     """Update Kandji Custom Script"""
-
-    # If script_name is not provided, set it from audit_script_path
-    if not script_name:
-        script_name = os.path.basename(audit_script_path)
 
     # Read Audit Script Content
     audit_script_content = ""
@@ -642,7 +634,7 @@ def sync_kandji_scripts(local_scripts, kandji_scripts, dryrun=False):
                     logger.info(f"[DRY RUN] Would update Kandji Custom Script Library Item: {configured_name}")
                 else:
                     logger.info(f"Updating Kandji Custom Script Library Item: {configured_name}")
-                    update_custom_script(kandji_script["id"], audit_script, remediation_script, script_name)
+                    update_custom_script(kandji_script["id"], audit_script, remediation_script)
             else:
                 logger.info(f"No changes detected for Kandji Custom Script Library Item: {configured_name}")
         else:
@@ -650,7 +642,7 @@ def sync_kandji_scripts(local_scripts, kandji_scripts, dryrun=False):
                 logger.info(f"[DRY RUN] Would create Kandji Custom Script Library Item: {configured_name}")
             else:
                 logger.info(f"Creating Kandji Custom Script Library Item: {configured_name}")
-                create_custom_script(audit_script, remediation_script, script_name)
+                create_custom_script(audit_script, remediation_script)
 
 # Sync Kandji Profiles
 def sync_kandji_profiles(local_profiles, kandji_profiles, dryrun=False):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 requests
+python-slugify


### PR DESCRIPTION
Unfortunately git2kandji hardcoded some configuration values for scripts like the name of the library item becoming the script name, execution frequency always being set to once and the script never being shown in Kandji self service.

This PR adds the capability to git2kandji to include configuration metadata into audit scripts which are then used to configure the library item accordingly.

As an example, scripts can now look like this:

```bash
#!/usr/bin/env bash

# git2kandji-config: name=Custom git2kandji Script Name
# git2kandji-config: active=false
# git2kandji-config: execution_frequency=every_15_min

echo "Audit: git2kandji"
```

PS: And I made the container image run as non-root user as a bonus 😉 